### PR TITLE
Fix IndexBuilder class name

### DIFF
--- a/src/IndexBuilder.php
+++ b/src/IndexBuilder.php
@@ -8,7 +8,7 @@ use \Exception;
 use \Phalcon\Db\Column;
 use \Phalcon\Mvc\Model;
 
-class Elasticsearch
+class IndexBuilder
 {
     /**
      * @var \Phalcon\Di


### PR DESCRIPTION
The IndexBuilder class was declared as 'Elasticsearch', so I renamed it to 'IndexBuilder' and it is working for me. @kaioken 