### PR TITLE
Add support to search documents without conditions

### DIFF
--- a/src/SearchTrait.php
+++ b/src/SearchTrait.php
@@ -119,7 +119,7 @@ trait SearchTrait
             }
         }
 
-        $sql = ' WHERE' . substr($sql, 4);
+        empty($sql) ?: $sql = ' WHERE' . substr($sql, 4);
 
         $resultsSql = 'SELECT ' . $fields . ' FROM ' . $model . $sql . ' ORDER BY ' . $sort . ($withLimit ? ' LIMIT ' . $offset . ', ' . $limit : '');
 


### PR DESCRIPTION
Currently, you can not search for some documents without specifying a query to condition the data because it will fail.
Now, we can get the first 20 documents without specifying conditions or filters to the documents.